### PR TITLE
feat: Added GetCurrentJulianDayRelativeToJ2000().

### DIFF
--- a/coverage.txt
+++ b/coverage.txt
@@ -1,5 +1,6 @@
 mode: atomic
-github.com/observerly/dusk/pkg/dusk/epoch.go:5.48,11.2 3 1
+github.com/observerly/dusk/pkg/dusk/epoch.go:20.48,25.2 2 2
+github.com/observerly/dusk/pkg/dusk/epoch.go:27.65,38.2 4 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:10.30,12.2 1 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:14.30,16.2 1 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:18.30,20.2 1 1
@@ -7,4 +8,3 @@ github.com/observerly/dusk/pkg/dusk/trigonometry.go:22.31,24.2 1 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:26.31,28.2 1 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:30.31,32.2 1 1
 github.com/observerly/dusk/pkg/dusk/trigonometry.go:34.36,36.2 1 1
-github.com/observerly/dusk/pkg/dusk/twilight.go:3.33,3.34 0 0

--- a/pkg/dusk/epoch.go
+++ b/pkg/dusk/epoch.go
@@ -1,6 +1,15 @@
 package dusk
 
-import "time"
+import (
+	"math"
+	"time"
+)
+
+// the epoch of Unix time start i.e., 1 January 1970 00:00:00 UTC:
+var J1970 float64 = 2440587.5
+
+// the epoch of Unix time start i.e., 1 January 2000 00:00:00 UTC:
+var J2000 float64 = 2451545.0
 
 /*
 	GetJulianDate()
@@ -9,11 +18,27 @@ import "time"
 	@see http://astro.vaporia.com/start/jd.html
 */
 func GetJulianDate(datetime time.Time) float64 {
-	// the epoch of Unix time start i.e., 1 January 1970 00:00:00 UTC:
-	var J1970 float64 = 2440587.5
-
 	// milliseconds elapsed since 1 January 1970 00:00:00 UTC up until now as an int64:
 	var time int64 = datetime.UTC().UnixNano() / 1e6
 
 	return float64(time)/86400000.0 + J1970
+}
+
+/*
+	GetCurrentJulianDayRelativeToJ2000()
+
+	@returns the number of Julian days between J2000 (i.e., 1 January 2000 00:00:00 UTC) and the the datetime, rounded up the the nearest integer
+	@see http://astro.vaporia.com/start/jd.html
+*/
+func GetCurrentJulianDayRelativeToJ2000(datetime time.Time) int {
+	// get the Julian date:
+	var JD float64 = GetJulianDate(datetime)
+
+	// correction for the the fractional Julian Day for leap seconds and terrestrial time (TT):
+	var corr float64 = 0.0008
+
+	// calculate the current Julian day:
+	var n float64 = math.Ceil(JD - 2451545.0 - corr)
+
+	return int(n)
 }

--- a/pkg/dusk/epoch_test.go
+++ b/pkg/dusk/epoch_test.go
@@ -17,3 +17,13 @@ func TestGetJulianDate(t *testing.T) {
 		t.Errorf("got %f, wanted %f", got, want)
 	}
 }
+
+func TestGetCurrentJulianDay(t *testing.T) {
+	var got int = GetCurrentJulianDayRelativeToJ2000(datetime)
+
+	var want int = 7804
+
+	if got != want {
+		t.Errorf("got %d, wanted %d", got, want)
+	}
+}


### PR DESCRIPTION
feat: Added GetCurrentJulianDayRelativeToJ2000() to dusk module. 

Includes minor refactor of J1970 and J2000 to epoch.go constants. 

Includes associated test suite for module export definition and expected output.