### PR TITLE
fix: Ensure HorizontlaCoordinates are capitalized for ext. usage.

### DIFF
--- a/pkg/dusk/coordinates.go
+++ b/pkg/dusk/coordinates.go
@@ -19,11 +19,11 @@ type HorizontalCoordinate struct {
 	/*
 		altitude (a) or elevation
 	*/
-	a float64
+	Altitude float64
 	/*
 		azimuth (A) or elevation
 	*/
-	A float64
+	Azimuth float64
 }
 
 type TemporalHorizontalCoordinate struct {
@@ -100,7 +100,7 @@ func ConvertEquatorialCoordinateToHorizontal(datetime time.Time, longitude float
 	var az = acosx((sinx(dec) - sinx(alt)*sinx(latitude)) / (cosx(alt) * cosx(latitude)))
 
 	return HorizontalCoordinate{
-		a: alt,
-		A: az,
+		Altitude: alt,
+		Azimuth:  az,
 	}
 }

--- a/pkg/dusk/coordinates_test.go
+++ b/pkg/dusk/coordinates_test.go
@@ -67,7 +67,7 @@ func TestConvertEclipticCoordinateToEquatorialDecAlt(t *testing.T) {
 func TestConvertEquatorialCoordinateTHorizontalAltitude(t *testing.T) {
 	var hz HorizontalCoordinate = ConvertEquatorialCoordinateToHorizontal(datetime, longitude, latitude, EquatorialCoordinate{RightAscension: 88.7929583, Declination: 7.4070639})
 
-	var got float64 = hz.a
+	var got float64 = hz.Altitude
 
 	var want float64 = 72.800882
 
@@ -79,7 +79,7 @@ func TestConvertEquatorialCoordinateTHorizontalAltitude(t *testing.T) {
 func TestConvertEquatorialCoordinateTHorizontalAzimuth(t *testing.T) {
 	var hz HorizontalCoordinate = ConvertEquatorialCoordinateToHorizontal(datetime, longitude, latitude, EquatorialCoordinate{RightAscension: 88.7929583, Declination: 7.4070639})
 
-	var got float64 = hz.A
+	var got float64 = hz.Azimuth
 
 	var want float64 = 134.397750
 

--- a/pkg/dusk/lunar.go
+++ b/pkg/dusk/lunar.go
@@ -744,8 +744,8 @@ func GetLunarHorizontalCoordinatesForDay(datetime time.Time, longitude float64, 
 
 		horizontalCoordinates[i] = TemporalHorizontalCoordinate{
 			Datetime: d,
-			Altitude: hz.a,
-			Azimuth:  hz.A,
+			Altitude: hz.Altitude,
+			Azimuth:  hz.Azimuth,
 		}
 
 		d = d.Add(time.Minute * 1)


### PR DESCRIPTION
BREAKING CHANGE: Ensure HorizontalCoordinates are capitalized for ext. usage i.e., a => Altitude and A => Azimuth.