### PR TITLE
fix: Ensured &Transit{ Duration : 0 } in return.

### DIFF
--- a/pkg/dusk/transit.go
+++ b/pkg/dusk/transit.go
@@ -119,8 +119,9 @@ func GetObjectRiseObjectSetTimesInUTC(datetime time.Time, eq EquatorialCoordinat
 func GetObjectRiseObjectSetTimes(datetime time.Time, eq EquatorialCoordinate, latitude float64, longitude float64) (*Transit, error) {
 	if !GetDoesObjectRiseOrSet(eq, latitude) {
 		return &Transit{
-			Rise: nil,
-			Set:  nil,
+			Rise:     nil,
+			Set:      nil,
+			Duration: 0,
 		}, nil
 	}
 


### PR DESCRIPTION
fix: Ensured &Transit{ Duration : 0 } in return.