### PR TITLE
chore: Upgraded go dependency to v1.20.*.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: CI/CD Build
     strategy:
       matrix:
-        go: [ '1.17.x', ]
+        go: [ '1.17.x', '1.18.x', '1.19.x', '1.20.x']
         os: [ ubuntu-latest ]
 
     runs-on: ${{ matrix.os }}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/observerly/dusk
 
-go 1.17
+go 1.20
 
 require github.com/zsefvlol/timezonemapper v1.0.0


### PR DESCRIPTION
chore: Upgraded go dependency to v1.20.* by running go mod edit -go=1.20. 

Includes adding go versions 1.19.x and 1.20.x to matrix strategy for testing.